### PR TITLE
Escape percents in strings that go into sprintf()

### DIFF
--- a/includes/Generator.php
+++ b/includes/Generator.php
@@ -16,7 +16,7 @@ class Generator
     {
         $this->empty_query = $empty_query;
     }
-                              	
+
     public function get_sqls( $args = [] )
     {
         $sqls = [];
@@ -37,22 +37,32 @@ class Generator
         return $sqls;
     }
 
+	static public function esc_percent( $in_string )
+	{
+        $return = str_replace( '%', '%%', $in_string );
+
+		return $return;
+	}
+
     public function get_request( $args = [], $union = '', $orderby = '', $ppp = 1, $paged = 1, $offset = 0 )
     {
         $request = '';
-        
+
 		$sqls = $this->get_sqls( $args );
-		
+
         if ( 0 < count( $sqls ) )
         {
+			$union = Generator::esc_percent( $union );
+			$sqls = Generator::esc_percent( $sqls );
+
             $unions  = '(' . join( ') ' . $union . ' (', $sqls ) . ' ) ';
-            $request = sprintf( 
+            $request = sprintf(
 				"SELECT SQL_CALC_FOUND_ROWS * FROM ( {$unions} ) as combined {$orderby} LIMIT %d, %d",
                 $ppp * ( $paged - 1 ) + $offset,
                 $ppp
             );
 		}
-		
+
         return $request;
     }
 


### PR DESCRIPTION
I'm evaluating this plugin code for a project I'm working on, and came across an error.

In a meta query, the `LIKE` comparison is being used, along with its wildcard %. Feeding this into the `sprintf()` in `Generator->get_request()` produces unintended output, as well as a warning-level error:

`PHP Warning:  sprintf(): Too few arguments in /srv/www/prulite/htdocs/wp-content/plugins/combined-query/includes/Generator.php on line 53` 

As triggered by:

```PHP
$args1 = array(
        'post_type' => 'product',
        's' => get_query_var( 's' ),
);

$args2 = array(
        'post_type' => 'product',
        'meta_query' => array(
                array(
                        'taxonomy' => 'tag',
                        'field' => 'name',
                        'terms' => get_query_var( 's' ),
                ),
        ),
);

$args = array(
        'combined_query' => array(
                'args' => array( $args1, $args2 ),
                'union' => 'UNION'
        )
);
```

